### PR TITLE
Remove init logic from coinbase placeholder

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -44,19 +44,16 @@
   },
   "linters": {
     "disable": [
-      "gochecknoglobals",
       "gocritic",
       "godot",
       "godox",
       "testifylint",
       "revive",
-      "gochecknoinits",
       "forbidigo",
       "err113",
       "errorlint",
       "gosec",
-      "unused",
-      "gomoddirectives"
+      "unused"
     ],
     "enable": [
       "asasalint",

--- a/coinbase_placeholder.go
+++ b/coinbase_placeholder.go
@@ -28,19 +28,17 @@ var (
 	FrozenBytesTxHash  = chainhash.Hash(FrozenBytesTxBytes)
 )
 
-var (
-	CoinbasePlaceholderTx     *bt.Tx
-	coinbasePlaceholderTxHash *chainhash.Hash
-)
-
-func init() {
-	CoinbasePlaceholderTx = bt.NewTx()
-	CoinbasePlaceholderTx.Version = 0xFFFFFFFF
-	CoinbasePlaceholderTx.LockTime = 0xFFFFFFFF
-
-	coinbasePlaceholderTxHash = CoinbasePlaceholderTx.TxIDChainHash()
+func generateCoinbasePlaceholderTx() *bt.Tx {
+	tx := bt.NewTx()
+	tx.Version = 0xFFFFFFFF
+	tx.LockTime = 0xFFFFFFFF
+	return tx
 }
 
+// IsCoinbasePlaceHolderTx checks if the given transaction is a coinbase placeholder transaction.
 func IsCoinbasePlaceHolderTx(tx *bt.Tx) bool {
+	coinbasePlaceholderTx := generateCoinbasePlaceholderTx()
+
+	coinbasePlaceholderTxHash := coinbasePlaceholderTx.TxIDChainHash()
 	return tx.TxIDChainHash().IsEqual(coinbasePlaceholderTxHash)
 }

--- a/coinbase_placeholder_test.go
+++ b/coinbase_placeholder_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 func TestCoinbasePlaceholderTx(t *testing.T) {
-	assert.True(t, IsCoinbasePlaceHolderTx(CoinbasePlaceholderTx))
-	assert.Equal(t, CoinbasePlaceholderTx.Version, uint32(0xFFFFFFFF))
-	assert.Equal(t, CoinbasePlaceholderTx.LockTime, uint32(0xFFFFFFFF))
-	assert.Equal(t, CoinbasePlaceholderTx.TxIDChainHash(), coinbasePlaceholderTxHash)
+	coinbasePlaceholderTx := generateCoinbasePlaceholderTx()
+	coinbasePlaceholderTxHash := coinbasePlaceholderTx.TxIDChainHash()
+	assert.True(t, IsCoinbasePlaceHolderTx(coinbasePlaceholderTx))
+	assert.Equal(t, coinbasePlaceholderTx.Version, uint32(0xFFFFFFFF))
+	assert.Equal(t, coinbasePlaceholderTx.LockTime, uint32(0xFFFFFFFF))
+	assert.Equal(t, coinbasePlaceholderTx.TxIDChainHash(), coinbasePlaceholderTxHash)
 	assert.False(t, IsCoinbasePlaceHolderTx(bt.NewTx()))
-	assert.Equal(t, "a8502e9c08b3c851201a71d25bf29fd38a664baedb777318b12d19242f0e46ab", CoinbasePlaceholderTx.TxIDChainHash().String())
+	assert.Equal(t, "a8502e9c08b3c851201a71d25bf29fd38a664baedb777318b12d19242f0e46ab", coinbasePlaceholderTx.TxIDChainHash().String())
 }


### PR DESCRIPTION
This pull request refactors the handling of coinbase placeholder transactions and updates linting configurations. The refactor simplifies the codebase by replacing global variables and initialization logic with a dedicated function, and the linting updates adjust the enabled and disabled linters for improved code quality.

### Refactoring of coinbase placeholder transactions:

* [`coinbase_placeholder.go`](diffhunk://#diff-7c8899085354cd0b83312337219534aa3909031acc74dffdd0851420c408889fL31-R42): Removed global variables `CoinbasePlaceholderTx` and `coinbasePlaceholderTxHash`, replacing them with a new `generateCoinbasePlaceholderTx` function. This improves encapsulation and eliminates the need for an `init` function.
* [`coinbase_placeholder_test.go`](diffhunk://#diff-3b1e2bfcf3aedd5469acd72c33f274909e11bcbaed802676db54e36a2a6b9e3eL11-R18): Updated tests to use the `generateCoinbasePlaceholderTx` function, ensuring consistency with the refactored implementation.

### Updates to linting configuration:

* [`.golangci.json`](diffhunk://#diff-7b9967b524b30a7e62fef0e2d0827b63026239c22e6f1c34bfad57d138b26edfL47-R56): Adjusted the list of disabled linters by removing `gochecknoglobals`, `gochecknoinits`, and `gomoddirectives`, while keeping `unused`. These changes align with the refactor and aim to enforce better coding practices.