### PR TITLE
[Docs] Remove install-template from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ govulncheck-install   ## Install govulncheck
 help                  ## Display this help message
 install-go            ## Install using go install with specific version
 install-releaser      ## Install GoReleaser
-install-template      ## Kick-start a fresh copy of go-subtree (run once!)
 install               ## Install the application binary
 lint                  ## Run the golangci-lint application (install if not found)
 release-snap          ## Build snapshot binaries


### PR DESCRIPTION
## What Changed
- Removed `install-template` from the Makefile commands list in `README.md`

## Why It Was Necessary
- The command is obsolete and should not appear in the documented `make help` output

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- Documentation only; no runtime impact.

Assigning to @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6866b7020d7c8321b192fddedb7222a6