### PR TITLE
feat: add RootHashPadded for fixed-height subtree composition

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,15 @@ var (
 
 	// ErrNodeNotFound is returned when a node is not found
 	ErrNodeNotFound = errors.New("node not found")
+
+	// ErrTargetHeightTooSmall is returned when RootHashPadded is asked to lift a
+	// subtree to a height that is smaller than the height implied by its current
+	// leaf count.
+	ErrTargetHeightTooSmall = errors.New("target height is smaller than the subtree's actual height")
+
+	// ErrNotPowerOfTwoLeafCount is returned when a subtree's actual leaf count is
+	// not a power of two, which violates the precondition for RootHashPadded.
+	ErrNotPowerOfTwoLeafCount = errors.New("subtree leaf count is not a power of two")
 )
 
 // Data mismatch errors

--- a/subtree.go
+++ b/subtree.go
@@ -3,6 +3,7 @@ package subtree
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -474,6 +475,48 @@ func (st *Subtree) RootHash() *chainhash.Hash {
 	st.rootHash, _ = chainhash.NewHash((*store)[len(*store)-1][:])
 
 	return st.rootHash
+}
+
+// RootHashPadded computes the merkle root of the subtree and then lifts it to
+// `targetHeight` by repeatedly hashing the root with itself (H(prev, prev) per
+// level), matching Bitcoin's duplicate-last-when-odd rule applied to phantom
+// slots. This makes the composition of subtree roots produce the same result as
+// building a single merkle tree over all leaves.
+//
+// Preconditions:
+//   - len(Nodes) must be a power of two (or 0).
+//   - targetHeight must be >= the height implied by the actual leaf count.
+//
+// Returns (nil, nil) for an empty subtree, matching RootHash's behavior.
+func (st *Subtree) RootHashPadded(targetHeight int) (*chainhash.Hash, error) {
+	if st == nil {
+		return nil, ErrSubtreeNil
+	}
+
+	length := st.Length()
+	if length == 0 {
+		return nil, nil //nolint:nilnil // mirrors RootHash's nil-for-empty contract; empty subtree is not an error condition
+	}
+
+	if !IsPowerOfTwo(length) {
+		return nil, ErrNotPowerOfTwoLeafCount
+	}
+
+	actualHeight := int(math.Log2(float64(length)))
+	if targetHeight < actualHeight {
+		return nil, ErrTargetHeightTooSmall
+	}
+
+	root := *st.RootHash()
+	for range targetHeight - actualHeight {
+		var buf [64]byte
+		copy(buf[0:32], root[:])
+		copy(buf[32:64], root[:])
+		first := sha256.Sum256(buf[:])
+		root = chainhash.Hash(sha256.Sum256(first[:]))
+	}
+
+	return &root, nil
 }
 
 // RootHashWithReplaceRootNode replaces the root node of the subtree with the given node and returns the new root hash.

--- a/subtree_padded_test.go
+++ b/subtree_padded_test.go
@@ -33,3 +33,89 @@ func TestRootHashPadded_LiftsTwoLeafSubtreeToHeightEight(t *testing.T) {
 
 	require.Equal(t, expected.String(), lifted.String())
 }
+
+func TestRootHashPadded_NoLiftWhenAlreadyAtTargetHeight(t *testing.T) {
+	st, err := NewTreeByLeafCount(4)
+	require.NoError(t, err)
+
+	for i := range 4 {
+		h := chainhash.HashH([]byte{byte(i)})
+		require.NoError(t, st.AddNode(h, 0, 0))
+	}
+
+	padded, err := st.RootHashPadded(2)
+	require.NoError(t, err)
+	require.Equal(t, st.RootHash().String(), padded.String())
+}
+
+func TestRootHashPadded_EmptySubtreeReturnsNil(t *testing.T) {
+	st, err := NewTreeByLeafCount(4)
+	require.NoError(t, err)
+
+	padded, err := st.RootHashPadded(2)
+	require.NoError(t, err)
+	require.Nil(t, padded)
+}
+
+func TestRootHashPadded_NotPowerOfTwoErrors(t *testing.T) {
+	st, err := NewTreeByLeafCount(4)
+	require.NoError(t, err)
+
+	h := chainhash.HashH([]byte{0x01})
+	require.NoError(t, st.AddNode(h, 0, 0))
+	h2 := chainhash.HashH([]byte{0x02})
+	require.NoError(t, st.AddNode(h2, 0, 0))
+	h3 := chainhash.HashH([]byte{0x03})
+	require.NoError(t, st.AddNode(h3, 0, 0))
+
+	_, err = st.RootHashPadded(2)
+	require.ErrorIs(t, err, ErrNotPowerOfTwoLeafCount)
+}
+
+func TestRootHashPadded_TargetHeightTooSmallErrors(t *testing.T) {
+	st, err := NewTreeByLeafCount(4)
+	require.NoError(t, err)
+
+	for i := range 4 {
+		h := chainhash.HashH([]byte{byte(i)})
+		require.NoError(t, st.AddNode(h, 0, 0))
+	}
+
+	_, err = st.RootHashPadded(1)
+	require.ErrorIs(t, err, ErrTargetHeightTooSmall)
+}
+
+func TestRootHashPadded_MatchesBigTreeRoot(t *testing.T) {
+	bigTree, err := NewTreeByLeafCount(16)
+	require.NoError(t, err)
+
+	hashes := make([]chainhash.Hash, 10)
+	for i := range hashes {
+		hashes[i] = chainhash.HashH([]byte{byte(i + 1)})
+		require.NoError(t, bigTree.AddNode(hashes[i], 0, 0))
+	}
+
+	left, err := NewTreeByLeafCount(8)
+	require.NoError(t, err)
+	for i := range 8 {
+		require.NoError(t, left.AddNode(hashes[i], 0, 0))
+	}
+
+	right, err := NewTreeByLeafCount(8)
+	require.NoError(t, err)
+	for i := 8; i < 10; i++ {
+		require.NoError(t, right.AddNode(hashes[i], 0, 0))
+	}
+
+	leftRoot, err := left.RootHashPadded(3)
+	require.NoError(t, err)
+	rightRoot, err := right.RootHashPadded(3)
+	require.NoError(t, err)
+
+	top, err := NewTreeByLeafCount(2)
+	require.NoError(t, err)
+	require.NoError(t, top.AddNode(*leftRoot, 0, 0))
+	require.NoError(t, top.AddNode(*rightRoot, 0, 0))
+
+	require.Equal(t, bigTree.RootHash().String(), top.RootHash().String())
+}

--- a/subtree_padded_test.go
+++ b/subtree_padded_test.go
@@ -119,3 +119,54 @@ func TestRootHashPadded_MatchesBigTreeRoot(t *testing.T) {
 
 	require.Equal(t, bigTree.RootHash().String(), top.RootHash().String())
 }
+
+// TestRootHashPadded_MatchesBitcoinRootAt258Txs proves at block scale that the
+// bitcoin merkle root of N transactions equals the root produced by composing
+// two fixed-height subtree roots — a complete left subtree and a partially-
+// filled right subtree lifted to the same height via RootHashPadded.
+//
+// Tree 1 holds all 258 leaves directly. NewIncompleteTreeByLeafCount(258)
+// rounds the capacity up to 512 (the next power of two), and the merkle
+// builder pads the unused slots with the zero hash; calcMerkle's "duplicate
+// the left child when the right is empty" rule then collapses those zeros
+// exactly the way bitcoin's "duplicate-last-when-odd" rule does, level by
+// level, so tree 1's RootHash() is the bitcoin-correct merkle root.
+func TestRootHashPadded_MatchesBitcoinRootAt258Txs(t *testing.T) {
+	const (
+		totalTxs        = 258
+		subtreeCapacity = 256
+	)
+
+	txHashes := make([]chainhash.Hash, totalTxs)
+	for i := range txHashes {
+		txHashes[i] = chainhash.HashH([]byte{byte(i), byte(i >> 8)})
+	}
+
+	tree1, err := NewIncompleteTreeByLeafCount(totalTxs)
+	require.NoError(t, err)
+	for _, h := range txHashes {
+		require.NoError(t, tree1.AddNode(h, 0, 0))
+	}
+	bitcoinRoot := tree1.RootHash()
+	require.NotNil(t, bitcoinRoot)
+
+	tree2, err := NewTreeByLeafCount(subtreeCapacity)
+	require.NoError(t, err)
+	for i := range subtreeCapacity {
+		require.NoError(t, tree2.AddNode(txHashes[i], 0, 0))
+	}
+
+	tree3, err := NewTreeByLeafCount(subtreeCapacity)
+	require.NoError(t, err)
+	require.NoError(t, tree3.AddNode(txHashes[256], 0, 0))
+	require.NoError(t, tree3.AddNode(txHashes[257], 0, 0))
+	tree3Root, err := tree3.RootHashPadded(tree2.Height)
+	require.NoError(t, err)
+
+	tree4, err := NewTreeByLeafCount(2)
+	require.NoError(t, err)
+	require.NoError(t, tree4.AddNode(*tree2.RootHash(), 0, 0))
+	require.NoError(t, tree4.AddNode(*tree3Root, 0, 0))
+
+	require.Equal(t, bitcoinRoot.String(), tree4.RootHash().String())
+}

--- a/subtree_padded_test.go
+++ b/subtree_padded_test.go
@@ -1,0 +1,35 @@
+package subtree
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootHashPadded_LiftsTwoLeafSubtreeToHeightEight(t *testing.T) {
+	st, err := NewTreeByLeafCount(256)
+	require.NoError(t, err)
+
+	h1, _ := chainhash.NewHashFromStr("97af9ad3583e2f83fc1e44e475e3a3ee31ec032449cc88b491479ef7d187c115")
+	h2, _ := chainhash.NewHashFromStr("7ce05dda56bc523048186c0f0474eb21c92fe35de6d014bd016834637a3ed08d")
+
+	require.NoError(t, st.AddNode(*h1, 0, 0))
+	require.NoError(t, st.AddNode(*h2, 0, 0))
+
+	lifted, err := st.RootHashPadded(8)
+	require.NoError(t, err)
+	require.NotNil(t, lifted)
+
+	expected := *st.RootHash()
+	for range 7 {
+		var buf [64]byte
+		copy(buf[0:32], expected[:])
+		copy(buf[32:64], expected[:])
+		first := sha256.Sum256(buf[:])
+		expected = chainhash.Hash(sha256.Sum256(first[:]))
+	}
+
+	require.Equal(t, expected.String(), lifted.String())
+}


### PR DESCRIPTION
## Summary

Adds `Subtree.RootHashPadded(targetHeight int) (*chainhash.Hash, error)` — a method that computes the subtree's merkle root and then lifts it to a caller-specified height by repeatedly hashing the root with itself (`H(prev, prev)` per phantom level). This is bitcoin's "duplicate-last-when-odd" rule applied to phantom slots above the actual leaves.

The motivation is to make subtree-root composition produce the same merkle root as building a single big merkle tree over all leaves, even when the last subtree is partial. Today, combining a complete subtree's root with a partial subtree's un-padded root yields a different value than the bitcoin merkle root over the same transactions — `RootHashPadded` closes that gap. Consumer (Teranode) intends to use it for block validation where one block carries multiple fixed-height subtrees and the final one may be incomplete.

## What's in the PR

- `errors.go`: two new sentinels — `ErrTargetHeightTooSmall`, `ErrNotPowerOfTwoLeafCount`.
- `subtree.go`: the `RootHashPadded` method, placed adjacent to `RootHash`.
- `subtree_padded_test.go`: seven tests covering the happy path, no-lift, empty-subtree, both error paths, an 8+2-leaves big-tree equivalence check, and a block-scale 258-tx (256+2 composition) equivalence check.

Purely additive — no existing behaviour changes.

### Preconditions enforced by RootHashPadded

- `len(Nodes)` must be a power of two (or zero) → otherwise `ErrNotPowerOfTwoLeafCount`.
- `targetHeight >= ceil(log2(len(Nodes)))` → otherwise `ErrTargetHeightTooSmall`.
- Empty subtree: returns `(nil, nil)` (matching `RootHash`'s nil-for-empty contract; guarded by a `//nolint:nilnil` directive with explanation).

## Test plan

- [x] `go test -race -count=1 ./...` — 76 tests pass, 0 failures
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --new-from-rev=master` — 0 issues
- [x] `go build ./...` — clean

## Note on archive status

I see the master README now carries an archive notice pointing to the go-stack monorepo. Happy to redirect this to go-stack if maintainers prefer — let me know. Submitting here first since (a) the repo isn't actually archived yet and (b) downstream consumers' go.mod still points here.