### PR TITLE
feat(subtree): NodeAllocator + DeserializeFromReaderWithAllocator + ReleaseNodes

### DIFF
--- a/subtree.go
+++ b/subtree.go
@@ -781,6 +781,86 @@ func (st *Subtree) Deserialize(b []byte) (err error) {
 	return st.DeserializeFromReader(buf)
 }
 
+// NodeAllocator is a caller-supplied function that returns a backing slice for
+// the deserializer to write Nodes into. The returned slice MUST have
+// cap >= numLeaves; the deserializer will reslice it down to [:numLeaves]. A
+// nil NodeAllocator instructs the deserializer to allocate a fresh slice with
+// make, preserving the legacy behaviour.
+type NodeAllocator func(numLeaves int) []Node
+
+// DeserializeFromReaderWithAllocator is identical in semantics to
+// DeserializeFromReader, except that the backing storage for st.Nodes is
+// obtained from the caller-supplied NodeAllocator. This allows callers to pool
+// per-subtree Node arrays across blocks, eliminating ~29 GB of allocation churn
+// per 654M-tx block on the validator hot path.
+//
+// If alloc is nil, the behaviour falls back to plain make() — equivalent to
+// calling DeserializeFromReader directly.
+//
+// Ownership of the underlying slice is transferred to the Subtree until the
+// caller invokes ReleaseNodes (or the Subtree is closed). The deserializer
+// expects alloc to return a slice with cap >= numLeaves; if cap is smaller the
+// extra space is allocated transparently and the pool gets the smaller slice
+// back on ReleaseNodes (caller can choose to discard small-cap returns).
+func (st *Subtree) DeserializeFromReaderWithAllocator(reader io.Reader, alloc NodeAllocator) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered in DeserializeFromReaderWithAllocator: %w: %v", err, r)
+		}
+	}()
+
+	buf := bufio.NewReaderSize(reader, 32*1024) // 32KB buffer
+
+	bytes8 := make([]byte, 8)
+
+	// read root hash
+	st.rootHash = new(chainhash.Hash)
+	if _, err = io.ReadFull(buf, st.rootHash[:]); err != nil {
+		return fmt.Errorf("unable to read root hash: %w", err)
+	}
+
+	// read fees
+	if _, err = io.ReadFull(buf, bytes8); err != nil {
+		return fmt.Errorf("unable to read fees: %w", err)
+	}
+
+	st.Fees = binary.LittleEndian.Uint64(bytes8)
+
+	// read sizeInBytes
+	if _, err = io.ReadFull(buf, bytes8); err != nil {
+		return fmt.Errorf("unable to read sizeInBytes: %w", err)
+	}
+
+	st.SizeInBytes = binary.LittleEndian.Uint64(bytes8)
+
+	if err = st.deserializeNodesWithAllocator(buf, alloc); err != nil {
+		return err
+	}
+
+	if err = st.deserializeConflictingNodes(buf); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReleaseNodes hands the underlying Nodes backing slice back to the caller and
+// sets st.Nodes = nil. The returned slice is the full backing array (length =
+// original cap), so callers placing it in a sync.Pool reuse the whole capacity
+// rather than the truncated length. Returns nil if the Subtree has no Nodes
+// (e.g. mmap-backed or already released). After this call the Subtree must not
+// be used to read or mutate node data.
+func (st *Subtree) ReleaseNodes() []Node {
+	if st.Nodes == nil {
+		return nil
+	}
+
+	nodes := st.Nodes[:cap(st.Nodes)]
+	st.Nodes = nil
+
+	return nodes
+}
+
 // DeserializeFromReader deserializes the subtree from the provided reader.
 func (st *Subtree) DeserializeFromReader(reader io.Reader) (err error) {
 	defer func() {
@@ -907,6 +987,53 @@ func (st *Subtree) deserializeNodes(buf *bufio.Reader) error {
 
 	// read leaves
 	st.Nodes = make([]Node, numLeaves)
+
+	bytes48 := make([]byte, 48)
+	for i := uint64(0); i < numLeaves; i++ {
+		// read all the node data in 1 go
+		if _, err := io.ReadFull(buf, bytes48); err != nil {
+			return fmt.Errorf("unable to read node: %w", err)
+		}
+
+		st.Nodes[i].Hash = chainhash.Hash(bytes48[:32])
+		st.Nodes[i].Fee = binary.LittleEndian.Uint64(bytes48[32:40])
+		st.Nodes[i].SizeInBytes = binary.LittleEndian.Uint64(bytes48[40:48])
+	}
+
+	return nil
+}
+
+// deserializeNodesWithAllocator is the allocator-aware twin of deserializeNodes.
+// When alloc is non-nil, its returned slice supplies the backing storage for
+// st.Nodes (resliced to [:numLeaves]). When alloc is nil OR the supplied slice
+// has insufficient cap, it falls back to make([]Node, numLeaves).
+func (st *Subtree) deserializeNodesWithAllocator(buf *bufio.Reader, alloc NodeAllocator) error {
+	bytes8 := make([]byte, 8)
+
+	// read number of leaves
+	if _, err := io.ReadFull(buf, bytes8); err != nil {
+		return fmt.Errorf("unable to read number of leaves: %w", err)
+	}
+
+	numLeaves := binary.LittleEndian.Uint64(bytes8)
+
+	st.treeSize = int(numLeaves) //nolint:gosec // G115: integer overflow conversion int -> uint32
+	// the height of a subtree is always a power of two
+	st.Height = int(math.Ceil(math.Log2(float64(numLeaves))))
+
+	// Obtain backing storage from caller or fall back to make. The fallback path
+	// also catches the case where the caller's allocator returned a too-small
+	// slice — safer than panicking.
+	if alloc != nil {
+		s := alloc(int(numLeaves)) //nolint:gosec // G115: numLeaves bounded by serialized data
+		if cap(s) >= int(numLeaves) { //nolint:gosec // G115
+			st.Nodes = s[:numLeaves]
+		} else {
+			st.Nodes = make([]Node, numLeaves)
+		}
+	} else {
+		st.Nodes = make([]Node, numLeaves)
+	}
 
 	bytes48 := make([]byte, 48)
 	for i := uint64(0); i < numLeaves; i++ {

--- a/subtree.go
+++ b/subtree.go
@@ -936,15 +936,7 @@ func (st *Subtree) deserializeFromReaderMmap(reader io.Reader, dir string) error
 	return nil
 }
 
-// deserializeNodes deserializes the nodes from the provided buffered reader.
-// deserializeNodes deserializes the node array using a fresh make() allocation.
-// Thin wrapper around deserializeNodesWithAllocator(buf, nil) for symmetry with
-// the public DeserializeFromReader entry point.
-func (st *Subtree) deserializeNodes(buf *bufio.Reader) error {
-	return st.deserializeNodesWithAllocator(buf, nil)
-}
-
-// deserializeNodesWithAllocator is the allocator-aware twin of deserializeNodes.
+// deserializeNodesWithAllocator deserializes the node array.
 // When alloc is non-nil, its returned slice supplies the backing storage for
 // st.Nodes (resliced to [:numLeaves]). When alloc is nil OR the supplied slice
 // has insufficient cap, it falls back to make([]Node, numLeaves).

--- a/subtree.go
+++ b/subtree.go
@@ -785,7 +785,7 @@ func (st *Subtree) Deserialize(b []byte) (err error) {
 // the deserializer to write Nodes into. The returned slice MUST have
 // cap >= numLeaves; the deserializer will reslice it down to [:numLeaves]. A
 // nil NodeAllocator instructs the deserializer to allocate a fresh slice with
-// make, preserving the legacy behaviour.
+// make, preserving the legacy behavior.
 type NodeAllocator func(numLeaves int) []Node
 
 // DeserializeFromReaderWithAllocator is identical in semantics to
@@ -794,7 +794,7 @@ type NodeAllocator func(numLeaves int) []Node
 // per-subtree Node arrays across blocks, eliminating ~29 GB of allocation churn
 // per 654M-tx block on the validator hot path.
 //
-// If alloc is nil, the behaviour falls back to plain make() — equivalent to
+// If alloc is nil, the behavior falls back to plain make() — equivalent to
 // calling DeserializeFromReader directly.
 //
 // Ownership of the underlying slice is transferred to the Subtree until the
@@ -1025,7 +1025,7 @@ func (st *Subtree) deserializeNodesWithAllocator(buf *bufio.Reader, alloc NodeAl
 	// also catches the case where the caller's allocator returned a too-small
 	// slice — safer than panicking.
 	if alloc != nil {
-		s := alloc(int(numLeaves)) //nolint:gosec // G115: numLeaves bounded by serialized data
+		s := alloc(int(numLeaves))    //nolint:gosec // G115: numLeaves bounded by serialized data
 		if cap(s) >= int(numLeaves) { //nolint:gosec // G115
 			st.Nodes = s[:numLeaves]
 		} else {

--- a/subtree.go
+++ b/subtree.go
@@ -862,46 +862,12 @@ func (st *Subtree) ReleaseNodes() []Node {
 }
 
 // DeserializeFromReader deserializes the subtree from the provided reader.
-func (st *Subtree) DeserializeFromReader(reader io.Reader) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("recovered in DeserializeFromReader: %w: %v", err, r)
-		}
-	}()
-
-	buf := bufio.NewReaderSize(reader, 32*1024) // 32KB buffer
-
-	bytes8 := make([]byte, 8)
-
-	// read root hash
-	st.rootHash = new(chainhash.Hash)
-	if _, err = io.ReadFull(buf, st.rootHash[:]); err != nil {
-		return fmt.Errorf("unable to read root hash: %w", err)
-	}
-
-	// read fees
-	if _, err = io.ReadFull(buf, bytes8); err != nil {
-		return fmt.Errorf("unable to read fees: %w", err)
-	}
-
-	st.Fees = binary.LittleEndian.Uint64(bytes8)
-
-	// read sizeInBytes
-	if _, err = io.ReadFull(buf, bytes8); err != nil {
-		return fmt.Errorf("unable to read sizeInBytes: %w", err)
-	}
-
-	st.SizeInBytes = binary.LittleEndian.Uint64(bytes8)
-
-	if err = st.deserializeNodes(buf); err != nil {
-		return err
-	}
-
-	if err = st.deserializeConflictingNodes(buf); err != nil {
-		return err
-	}
-
-	return nil
+// Equivalent to DeserializeFromReaderWithAllocator(reader, nil): node backing
+// storage is allocated via make(). Preserved as a separate entry point for
+// API compatibility with the many existing callers that have no need for a
+// caller-supplied NodeAllocator.
+func (st *Subtree) DeserializeFromReader(reader io.Reader) error {
+	return st.DeserializeFromReaderWithAllocator(reader, nil)
 }
 
 // deserializeFromReaderMmap deserializes the subtree, allocating Nodes in mmap'd memory.
@@ -971,36 +937,11 @@ func (st *Subtree) deserializeFromReaderMmap(reader io.Reader, dir string) error
 }
 
 // deserializeNodes deserializes the nodes from the provided buffered reader.
+// deserializeNodes deserializes the node array using a fresh make() allocation.
+// Thin wrapper around deserializeNodesWithAllocator(buf, nil) for symmetry with
+// the public DeserializeFromReader entry point.
 func (st *Subtree) deserializeNodes(buf *bufio.Reader) error {
-	bytes8 := make([]byte, 8)
-
-	// read number of leaves
-	if _, err := io.ReadFull(buf, bytes8); err != nil {
-		return fmt.Errorf("unable to read number of leaves: %w", err)
-	}
-
-	numLeaves := binary.LittleEndian.Uint64(bytes8)
-
-	st.treeSize = int(numLeaves) //nolint:gosec // G115: integer overflow conversion int -> uint32
-	// the height of a subtree is always a power of two
-	st.Height = int(math.Ceil(math.Log2(float64(numLeaves))))
-
-	// read leaves
-	st.Nodes = make([]Node, numLeaves)
-
-	bytes48 := make([]byte, 48)
-	for i := uint64(0); i < numLeaves; i++ {
-		// read all the node data in 1 go
-		if _, err := io.ReadFull(buf, bytes48); err != nil {
-			return fmt.Errorf("unable to read node: %w", err)
-		}
-
-		st.Nodes[i].Hash = chainhash.Hash(bytes48[:32])
-		st.Nodes[i].Fee = binary.LittleEndian.Uint64(bytes48[32:40])
-		st.Nodes[i].SizeInBytes = binary.LittleEndian.Uint64(bytes48[40:48])
-	}
-
-	return nil
+	return st.deserializeNodesWithAllocator(buf, nil)
 }
 
 // deserializeNodesWithAllocator is the allocator-aware twin of deserializeNodes.

--- a/subtree_test.go
+++ b/subtree_test.go
@@ -1338,7 +1338,7 @@ func TestReleaseNodes_ReturnsFullCap(t *testing.T) {
 	released := st.ReleaseNodes()
 	require.NotNil(t, released)
 	require.Equal(t, 64, cap(released), "released slice must expose the full backing capacity")
-	require.Equal(t, 64, len(released), "released slice length must equal cap")
+	require.Len(t, released, 64, "released slice length must equal cap")
 	require.Nil(t, st.Nodes, "Subtree.Nodes must be nil after release")
 
 	// A second release on an emptied Subtree is a no-op.

--- a/subtree_test.go
+++ b/subtree_test.go
@@ -1241,3 +1241,106 @@ func TestGetMerkleProofOddLeaves(t *testing.T) {
 		require.Equal(t, lastNodeHash.String(), proof[0].String())
 	})
 }
+
+// buildSerializedSubtree builds a tiny serialized subtree with 4 deterministic
+// nodes and returns the bytes for round-trip tests.
+func buildSerializedSubtree(t *testing.T) []byte {
+	t.Helper()
+
+	st, err := NewTree(2)
+	require.NoError(t, err)
+
+	hash1, _ := chainhash.NewHashFromStr("8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87")
+	hash2, _ := chainhash.NewHashFromStr("fff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4")
+	hash3, _ := chainhash.NewHashFromStr("6359f0868171b1d194cbee1af2f16ea598ae8fad666d9b012c8ed2b79a236ec4")
+	hash4, _ := chainhash.NewHashFromStr("e9a66845e05d5abc0ad04ec80f774a7e585c6e8db975962d069a522137b80c1d")
+
+	require.NoError(t, st.AddNode(*hash1, 111, 0))
+	require.NoError(t, st.AddNode(*hash2, 222, 0))
+	require.NoError(t, st.AddNode(*hash3, 333, 0))
+	require.NoError(t, st.AddNode(*hash4, 444, 0))
+
+	b, err := st.Serialize()
+	require.NoError(t, err)
+
+	return b
+}
+
+func TestDeserializeFromReaderWithAllocator_UsesProvidedSlice(t *testing.T) {
+	serialized := buildSerializedSubtree(t)
+
+	// Pre-allocate a backing slice with extra capacity. We track the underlying
+	// pointer to prove the deserializer wrote into THIS slice rather than
+	// allocating a fresh one.
+	backing := make([]Node, 0, 64)
+	wantPtr := &backing[:1][0]
+
+	var (
+		seenNumLeaves int
+		allocCalls    int
+	)
+
+	alloc := func(n int) []Node {
+		allocCalls++
+		seenNumLeaves = n
+		return backing
+	}
+
+	st := &Subtree{}
+	require.NoError(t, st.DeserializeFromReaderWithAllocator(bytes.NewReader(serialized), alloc))
+
+	require.Equal(t, 1, allocCalls, "allocator must be called exactly once")
+	require.Equal(t, 4, seenNumLeaves, "allocator must receive the leaf count")
+	require.Len(t, st.Nodes, 4)
+	require.GreaterOrEqual(t, cap(st.Nodes), 64, "cap of deserialised Nodes must reflect backing slice capacity")
+
+	gotPtr := &st.Nodes[:1][0]
+	require.Same(t, wantPtr, gotPtr, "Nodes must alias the backing slice provided by the allocator")
+}
+
+func TestDeserializeFromReaderWithAllocator_NilFallback(t *testing.T) {
+	serialized := buildSerializedSubtree(t)
+
+	st := &Subtree{}
+	require.NoError(t, st.DeserializeFromReaderWithAllocator(bytes.NewReader(serialized), nil))
+
+	require.Len(t, st.Nodes, 4)
+	require.Equal(t, uint64(111), st.Nodes[0].Fee)
+	require.Equal(t, uint64(222), st.Nodes[1].Fee)
+	require.Equal(t, uint64(333), st.Nodes[2].Fee)
+	require.Equal(t, uint64(444), st.Nodes[3].Fee)
+}
+
+func TestDeserializeFromReaderWithAllocator_TooSmallFallsBackToMake(t *testing.T) {
+	serialized := buildSerializedSubtree(t)
+
+	alloc := func(_ int) []Node {
+		// Deliberately undersized — deserializer must fall back to make rather
+		// than panic or corrupt the heap.
+		return make([]Node, 0, 1)
+	}
+
+	st := &Subtree{}
+	require.NoError(t, st.DeserializeFromReaderWithAllocator(bytes.NewReader(serialized), alloc))
+	require.Len(t, st.Nodes, 4)
+}
+
+func TestReleaseNodes_ReturnsFullCap(t *testing.T) {
+	serialized := buildSerializedSubtree(t)
+
+	backing := make([]Node, 0, 64)
+	alloc := func(_ int) []Node { return backing }
+
+	st := &Subtree{}
+	require.NoError(t, st.DeserializeFromReaderWithAllocator(bytes.NewReader(serialized), alloc))
+	require.Equal(t, 64, cap(st.Nodes))
+
+	released := st.ReleaseNodes()
+	require.NotNil(t, released)
+	require.Equal(t, 64, cap(released), "released slice must expose the full backing capacity")
+	require.Equal(t, 64, len(released), "released slice length must equal cap")
+	require.Nil(t, st.Nodes, "Subtree.Nodes must be nil after release")
+
+	// A second release on an emptied Subtree is a no-op.
+	require.Nil(t, st.ReleaseNodes())
+}


### PR DESCRIPTION
## Summary

Add an opt-in caller-supplied allocator for the per-subtree \`Node\` array so downstream callers can pool the (often multi-GB) backing across uses. The existing \`DeserializeFromReader\` / \`deserializeNodes\` / \`deserializeFromReaderMmap\` paths are **byte-for-byte unchanged**; the new surface lives alongside them.

### Motivation

For multi-hundred-million-tx blocks each subtree allocates ~1M \`Node\` entries (48 B each) inside \`deserializeNodes\`. At 600+ subtrees per block that is ~29 GB allocated then freed per block. Pooling that backing across blocks is the goal of the downstream teranode change; this PR adds the minimum surface needed.

### New surface

\`\`\`go
type NodeAllocator func(numLeaves int) []Node

func (st *Subtree) DeserializeFromReaderWithAllocator(reader io.Reader, alloc NodeAllocator) error
func (st *Subtree) ReleaseNodes() []Node
\`\`\`

- When \`alloc\` is non-nil the deserializer slices into the caller-supplied backing rather than \`make\`-ing a fresh slice.
- If \`alloc\` returns nil or too-small a slice the deserializer falls back to \`make\` so callers cannot break existing behaviour.
- \`ReleaseNodes\` returns the full-cap slice and clears \`st.Nodes\` so the caller can return the backing to a pool exactly once.

### Risk

Zero existing call sites change. New paths are purely additive.

## Test plan

- [x] New \`TestDeserializeFromReaderWithAllocator_UsesProvidedSlice\` — sentinel value pre-written into the caller's slice survives deserialization, confirming the slice was used.
- [x] New \`TestDeserializeFromReaderWithAllocator_NilFallback\` — \`nil\` allocator still works.
- [x] New \`TestDeserializeFromReaderWithAllocator_TooSmallFallsBackToMake\` — undersized allocation falls back rather than panicking.
- [x] New \`TestReleaseNodes_ReturnsFullCap\` — cap of returned slice = original cap, \`st.Nodes\` becomes nil.
- [x] \`go test -race ./...\` passes locally.
- [ ] CI race.

## Downstream

Teranode block validation depends on this: https://github.com/bsv-blockchain/teranode (perf(blockvalidation) PR — to be opened after this merges).