### PR TITLE
fix(inpoints): NewTxInpoints returns non-nil empty ParentTxHashes

### DIFF
--- a/inpoints.go
+++ b/inpoints.go
@@ -67,10 +67,19 @@ type TxInpoints struct {
 // append-driven growth. With the packed layout the upper bound on slice size
 // is always known at construction time (len(tx.Inputs)), so callers that build
 // from a tx should use NewTxInpointsFromTx / NewTxInpointsFromInputs which
-// size exactly and never re-grow. NewTxInpoints exists for callers that want
-// an empty zero-value placeholder; it allocates nothing.
+// size exactly and never re-grow.
+//
+// NewTxInpoints exists for callers that want an empty placeholder. The
+// returned value has a non-nil-but-empty ParentTxHashes — Meta.Serialize
+// distinguishes "no inpoints set yet" (nil) from "this node has no parents"
+// (empty), and SubtreeMeta consumers depend on the latter shape for
+// non-coinbase nodes that legitimately have zero unique parents. The slice
+// header points at the runtime's zero-cap sentinel, so no heap allocation
+// is incurred.
 func NewTxInpoints() TxInpoints {
-	return TxInpoints{}
+	return TxInpoints{
+		ParentTxHashes: []chainhash.Hash{},
+	}
 }
 
 // NewTxInpointsFromTx creates a new TxInpoints object from a given transaction.


### PR DESCRIPTION
## Summary

`Meta.Serialize` rejects nil `TxInpoints[i].ParentTxHashes` for non-coinbase nodes (`subtree_meta.go:174`). Prior to the packed-layout rewrite in v1.4.0 the cap-8 constructor produced a non-nil-but-empty slice, so callers that initialised \`TxInpoints\` to \"empty\" via \`NewTxInpoints\` satisfied that check naturally.

v1.4.0 returns the zero value, breaking downstream consumers that rely on a non-nil sentinel to distinguish \"set, no parents\" from \"not set\".

This restores the empty-but-non-nil \`ParentTxHashes\` — a slice header pointing to the runtime's zero-cap sentinel array, so no heap allocation is incurred.

## Surfaced by

teranode CI after the v1.4.0 bump (https://github.com/bsv-blockchain/teranode/pull/889):

\`\`\`
TestBlock_ValidateSubtree_MissingParents/multiple_invalid_parents
TestBlock_ValidateSubtree_NodeIteration/subtree_with_multiple_nodes_iteration
\`\`\`

both fail with \`cannot serialize, parent tx hashes are not set for node N\`.

## Test plan

- [x] \`go test -race ./...\` green
- [ ] Cut **v1.4.1** after merge so downstream consumers can pin.