### PR TITLE
feat(subtree): RootHashPadded accepts non-power-of-two leaf counts

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,10 +49,6 @@ var (
 	// subtree to a height that is smaller than the height implied by its current
 	// leaf count.
 	ErrTargetHeightTooSmall = errors.New("target height is smaller than the subtree's actual height")
-
-	// ErrNotPowerOfTwoLeafCount is returned when a subtree's actual leaf count is
-	// not a power of two, which violates the precondition for RootHashPadded.
-	ErrNotPowerOfTwoLeafCount = errors.New("subtree leaf count is not a power of two")
 )
 
 // Data mismatch errors

--- a/subtree.go
+++ b/subtree.go
@@ -504,7 +504,7 @@ func (st *Subtree) RootHashPadded(targetHeight int) (*chainhash.Hash, error) {
 		return nil, nil //nolint:nilnil // mirrors RootHash's nil-for-empty contract; empty subtree is not an error condition
 	}
 
-	actualHeight := bits.Len(uint(length - 1)) //nolint:gosec // G115: length >= 1 here, so length-1 >= 0
+	actualHeight := bits.Len(uint(length - 1))
 	if targetHeight < actualHeight {
 		return nil, ErrTargetHeightTooSmall
 	}

--- a/subtree.go
+++ b/subtree.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"math"
+	"math/bits"
 	"sync"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -483,9 +484,14 @@ func (st *Subtree) RootHash() *chainhash.Hash {
 // slots. This makes the composition of subtree roots produce the same result as
 // building a single merkle tree over all leaves.
 //
+// The subtree's leaf count does NOT need to be a power of two:
+// BuildMerkleTreeStoreFromBytes already applies the duplicate-when-odd rule at
+// every internal level, so the natural root lives at height
+// ceil(log2(length)) for any length >= 1. Self-hashing from there up to
+// targetHeight composes correctly with the canonical flat merkle tree.
+//
 // Preconditions:
-//   - len(Nodes) must be a power of two (or 0).
-//   - targetHeight must be >= the height implied by the actual leaf count.
+//   - targetHeight must be >= ceil(log2(length)) implied by the actual leaf count.
 //
 // Returns (nil, nil) for an empty subtree, matching RootHash's behavior.
 func (st *Subtree) RootHashPadded(targetHeight int) (*chainhash.Hash, error) {
@@ -498,11 +504,7 @@ func (st *Subtree) RootHashPadded(targetHeight int) (*chainhash.Hash, error) {
 		return nil, nil //nolint:nilnil // mirrors RootHash's nil-for-empty contract; empty subtree is not an error condition
 	}
 
-	if !IsPowerOfTwo(length) {
-		return nil, ErrNotPowerOfTwoLeafCount
-	}
-
-	actualHeight := int(math.Log2(float64(length)))
+	actualHeight := bits.Len(uint(length - 1)) //nolint:gosec // G115: length >= 1 here, so length-1 >= 0
 	if targetHeight < actualHeight {
 		return nil, ErrTargetHeightTooSmall
 	}

--- a/subtree_padded_test.go
+++ b/subtree_padded_test.go
@@ -2,6 +2,7 @@ package subtree
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
@@ -57,8 +58,14 @@ func TestRootHashPadded_EmptySubtreeReturnsNil(t *testing.T) {
 	require.Nil(t, padded)
 }
 
-func TestRootHashPadded_NotPowerOfTwoErrors(t *testing.T) {
-	st, err := NewTreeByLeafCount(4)
+// TestRootHashPadded_AcceptsNonPowerOfTwoLeafCount verifies that RootHashPadded
+// accepts subtrees whose leaf count is not a power of two and returns a lifted
+// root that matches the canonical flat merkle tree at the same height. The
+// duplicate-when-odd rule applied inside BuildMerkleTreeStoreFromBytes already
+// pads the natural root to height ceil(log2(length)), so no special handling
+// is needed at the caller.
+func TestRootHashPadded_AcceptsNonPowerOfTwoLeafCount(t *testing.T) {
+	st, err := NewIncompleteTreeByLeafCount(3)
 	require.NoError(t, err)
 
 	h := chainhash.HashH([]byte{0x01})
@@ -68,8 +75,23 @@ func TestRootHashPadded_NotPowerOfTwoErrors(t *testing.T) {
 	h3 := chainhash.HashH([]byte{0x03})
 	require.NoError(t, st.AddNode(h3, 0, 0))
 
-	_, err = st.RootHashPadded(2)
-	require.ErrorIs(t, err, ErrNotPowerOfTwoLeafCount)
+	// ceil(log2(3)) == 2, so the natural root already sits at height 2.
+	padded, err := st.RootHashPadded(2)
+	require.NoError(t, err)
+	require.Equal(t, st.RootHash().String(), padded.String())
+
+	// Lifting one level above the natural height should self-hash once.
+	lifted, err := st.RootHashPadded(3)
+	require.NoError(t, err)
+
+	expected := *st.RootHash()
+	var buf [64]byte
+	copy(buf[0:32], expected[:])
+	copy(buf[32:64], expected[:])
+	first := sha256.Sum256(buf[:])
+	expected = chainhash.Hash(sha256.Sum256(first[:]))
+
+	require.Equal(t, expected.String(), lifted.String())
 }
 
 func TestRootHashPadded_TargetHeightTooSmallErrors(t *testing.T) {
@@ -169,4 +191,58 @@ func TestRootHashPadded_MatchesBitcoinRootAt258Txs(t *testing.T) {
 	require.NoError(t, tree4.AddNode(*tree3Root, 0, 0))
 
 	require.Equal(t, bitcoinRoot.String(), tree4.RootHash().String())
+}
+
+// TestRootHashPadded_MatchesFlatTreeForNonPowerOfTwoFinal sweeps a range of
+// non-power-of-two leaf counts in the final subtree and verifies that the
+// composed root (complete left subtree + lifted right subtree) equals the
+// canonical flat merkle root for each case. The chosen `r` values cover
+// different duplicate-when-odd cascade depths within a capacity-32 subtree.
+func TestRootHashPadded_MatchesFlatTreeForNonPowerOfTwoFinal(t *testing.T) {
+	const subtreeSize = 32
+
+	rValues := []int{1, 2, 3, 5, 6, 7, 9, 11, 13, 15, 17, 21, 23, 27, 31}
+
+	for _, r := range rValues {
+		t.Run(fmt.Sprintf("final_subtree_has_%d_leaves", r), func(t *testing.T) {
+			totalTxs := subtreeSize + r
+
+			txHashes := make([]chainhash.Hash, totalTxs)
+			for i := range txHashes {
+				txHashes[i] = chainhash.HashH([]byte{byte(i), byte(i >> 8)})
+			}
+
+			reference, err := NewIncompleteTreeByLeafCount(totalTxs)
+			require.NoError(t, err)
+			for _, h := range txHashes {
+				require.NoError(t, reference.AddNode(h, 0, 0))
+			}
+			referenceRoot := reference.RootHash()
+			require.NotNil(t, referenceRoot)
+
+			left, err := NewTreeByLeafCount(subtreeSize)
+			require.NoError(t, err)
+			for i := range subtreeSize {
+				require.NoError(t, left.AddNode(txHashes[i], 0, 0))
+			}
+
+			right, err := NewIncompleteTreeByLeafCount(r)
+			require.NoError(t, err)
+			for i := subtreeSize; i < totalTxs; i++ {
+				require.NoError(t, right.AddNode(txHashes[i], 0, 0))
+			}
+			require.Equal(t, r, right.Length())
+
+			rightLifted, err := right.RootHashPadded(left.Height)
+			require.NoError(t, err)
+
+			top, err := NewTreeByLeafCount(2)
+			require.NoError(t, err)
+			require.NoError(t, top.AddNode(*left.RootHash(), 0, 0))
+			require.NoError(t, top.AddNode(*rightLifted, 0, 0))
+
+			require.Equal(t, referenceRoot.String(), top.RootHash().String(),
+				"composed root must equal canonical flat root for r=%d", r)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The pow2 precondition on `RootHashPadded` was overly strict. The natural root produced by `BuildMerkleTreeStoreFromBytes` already lives at height `ceil(log2(length))` for any `length >= 1` because the duplicate-when-odd rule is applied at every internal level. Self-hashing from there up to `targetHeight` composes correctly with the canonical flat merkle tree.

## Changes

- Replace `int(math.Log2(float64(length)))` with `bits.Len(uint(length-1))` so the height calculation is exact for non-power-of-two lengths.
- Drop the `IsPowerOfTwo` guard and the now-unused `ErrNotPowerOfTwoLeafCount` sentinel from the public API.
- Convert the prior error-path test (`TestRootHashPadded_NotPowerOfTwoErrors`) into an acceptance test that asserts the lifted root matches both the natural root (when `targetHeight == ceil(log2(length))`) and the expected self-hashed value one level above.
- Add `TestRootHashPadded_MatchesFlatTreeForNonPowerOfTwoFinal`, a sweep across ``r ∈ {1,2,3,5,6,7,9,11,13,15,17,21,23,27,31}`` that proves the composed root (complete left + lifted right) equals the canonical flat merkle root for each remainder size.

## Motivation

This enables teranode PR [#909](https://github.com/bsv-blockchain/teranode/pull/909) to delete duplicate lift-helper code (~40 lines across two files) and call `RootHashPadded` directly for the legacy-block partitioner's final subtree of arbitrary length.

## Breaking change?

`ErrNotPowerOfTwoLeafCount` is removed from the public API. A grep across this repo and teranode shows no other callers; the only test using it has been converted. External consumers (if any) catching this sentinel would need to drop that branch.

## Test plan

- [x] `go test -race ./...` (all green, including the new sweep test)
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (no new issues introduced)